### PR TITLE
Ignore `skin-tone-x` modifiers when checking emoji

### DIFF
--- a/testimonials.py
+++ b/testimonials.py
@@ -292,8 +292,8 @@ def _count_upvotes_on_message(slack_message):
     total = 0
     reactions = slack_message["reactions"]
     for reaction in reactions:
-        # Count everything except for downvotes as upvotes
-        if reaction["name"] != "+1":
+        # Count everything except for downvotes as upvotes, ignoring skin-tone
+        if reaction["name"].split("::")[0] != "+1":
             continue
 
         count = reaction["count"]


### PR DESCRIPTION
## Summary:
We simply split the reaction name on `::` and evaluate the first bit to
see if it's a targeted emoji.

Issue: none

## Test plan:
make a skin-tone vote and see what happens