### PR TITLE
Screen weird testimonials

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ standard application. Deploy these by running `make deploy`. To test that the
 deploy succeeded, you can hit `/test_new_testimonial` and verify that a new
 default testimonial is sent to the `#testimonials` channel.
 
+For access to the App Engine part of this application, ask #it for access to
+khan-testimonials-turtle GCP project.
+
 The slack client that listens for reactions to slack messages and updates vote
 totals (`listener.py`) runs on toby, using the configuration found
 [here](https://github.com/Khan/aws-config/blob/master/toby/etc/systemd/system/slack-testimonials-bot.service).
@@ -37,3 +40,8 @@ sudo systemctl restart slack-testimonials-bot
 
 To test that this deploy succeeded, upvote a recently high quality testimonial.
 This should eventually reshare that testimonial to the `#khan-academy` channel.
+
+== Fixing when it breaks
+
+If something is weird with the App Engine deployment, try going in to cloud
+storage and wiping the staging bucket in there.

--- a/testimonials.py
+++ b/testimonials.py
@@ -137,7 +137,7 @@ def _sanitize_search_results(match):
     return testimonial
 
 
-# Paramters, subject to change
+# Parameters, subject to change
 QUERY_SIZE = 20
 MAX_TO_SHOW = 5
 
@@ -444,6 +444,15 @@ def notify_testimonials_channel(testimonial):
     testimonial on khanacademy.org/stories or via forwarding an email to
     testimonials_turtle@khan-academy.appspotmail.com
     """
+
+    # NOTE(drosile) as of August 2022, a user or users with these author names
+    # are submitting what look like machine learning generated testimonials
+    # that are very lengthy and spam the slack channel. we assume they'll give
+    # up eventually, but in the meantime, we can at least not spam ourselves.
+    author = testimonial.author_name.lower()
+    if author is 'derek ward' or author is 'kingstarz phoenix':
+        return
+
     _send_testimonial_notification(_TESTIMONIALS_CHANNEL, testimonial)
 
 


### PR DESCRIPTION
Someone (or maybe more than one?) keeps spamming the testimonials with
weird, perhaps ML-generated testimonials. Let's stop them from getting
posted to Slack.