### PR TITLE
Convert the slack testimonials-bot to python3.

### DIFF
--- a/listener.py
+++ b/listener.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """Tool for listening to testimonial-related activity in KA's slack channels.
 
 Listener connects to slack's real-time messaging API, keeps an eye on any
@@ -37,7 +39,7 @@ def handle_messages(messages):
                 testimonials.maybe_get_reacted_to_testimonial_message(message))
         if reacted_to_message:
             testimonials.send_updated_reaction_totals(message,
-                    reacted_to_message)
+                                                      reacted_to_message)
 
 
 def listen():

--- a/testimonials.py
+++ b/testimonials.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import logging
 import re
-import urlparse
+import urllib.parse
 
 import alertlib
 import humanize
@@ -155,8 +155,9 @@ def _query_for_channel_name_and_phrases(channel_name, phrases):
         query=query,
         count=QUERY_SIZE)
 
-    return filter(None,
-        map(_sanitize_search_results, resp['messages']['matches']))
+    return [r
+            for r in map(_sanitize_search_results, resp['messages']['matches'])
+            if r]
 
 
 def post_search_results(channel_id, search_phrase, requester):
@@ -174,8 +175,8 @@ def post_search_results(channel_id, search_phrase, requester):
 
         # Build a set of title_link's, which can be used to check uniqueness
         # of the testimonials
-        title_links = map(lambda t: t.get('title_link', None), testimonials)
-        title_link_set = set(filter(None, title_links))
+        title_links = [t.get('title_link', None) for t in testimonials]
+        title_link_set = set([tl for tl in title_links if tl])
 
         for testimonial in backup_testimonials[:room_left]:
             if testimonial.get('title_link', '') not in title_link_set:
@@ -319,8 +320,8 @@ def _parse_urlsafe_key_from_message(slack_message):
         return None
 
     title_link = slack_message["attachments"][0].get("title_link", None)
-    parsed_url = urlparse.urlparse(title_link)
-    query_dict = urlparse.parse_qs(parsed_url.query)
+    parsed_url = urllib.parse.urlparse(title_link)
+    query_dict = urllib.parse.parse_qs(parsed_url.query)
     vals = query_dict.get("key", [None])
 
     return vals[0]

--- a/testimonials_test.py
+++ b/testimonials_test.py
@@ -7,6 +7,7 @@ sys.modules['secrets'] = unittest.mock.Mock()
 
 import testimonials
 
+
 class TestTestimonials(unittest.TestCase):
     def test_search(self):
         """Tests the search functionality of the slack bot"""
@@ -68,6 +69,7 @@ class TestTestimonials(unittest.TestCase):
 
         self.assertIn("@%s" % requester, message_header)
         self.assertIn("no results found", message_header)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/testimonials_test.py
+++ b/testimonials_test.py
@@ -1,6 +1,9 @@
 import json
-from mock import MagicMock
+import sys
+import unittest.mock
 import unittest
+
+sys.modules['secrets'] = unittest.mock.Mock()
 
 import testimonials
 

--- a/webapp_api_client.py
+++ b/webapp_api_client.py
@@ -3,8 +3,8 @@ import logging
 
 import base64
 import json
-import urllib2
 import os
+import urllib.request
 
 import bot_globals
 import secrets
@@ -65,16 +65,16 @@ def _webapp_graphql_mutation(mutation, variables, operation_name):
 
     # To pass CSRF checking, we randomly generate a key and include it as a
     # header and a cookie.
-    fkey = base64.urlsafe_b64encode(os.urandom(16))
+    fkey = base64.urlsafe_b64encode(os.urandom(16)).decode('utf-8')
     headers = {
             'Content-Type': 'application/json',
             'X-Ka-Fkey': fkey,
             'Cookie': 'fkey=%s' % fkey
     }
-    req = urllib2.Request(url, data, headers)
+    req = urllib.request.Request(url, data, headers)
     try:
-        urllib2.urlopen(req)
-    except Exception, e:
+        urllib.request.urlopen(req)
+    except Exception as e:
         # Gently fail if we ever fail to talk to the KA API: record the error,
         # return None, and let the listener live on.
         logging.error("Failed to send post to KA webapp API: %s" % e)


### PR DESCRIPTION
## Summary:
We have removed python2 from webapp, and now we are removing it from
all our jenkins machines. That means that these scripts need to run
under python3! I used 2to3 to do the conversion, then fixed up
subprocess and friends by hand.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9839

## Test plan:
I'm not even exactly sure if this is still running.  But my plan
is to update toby with this new code, restart the testimonials-bot
if possible, and try hitting the endpoints.