### PR TITLE
[🔥AUDIT🔥] The new slack library has WebClient, not SlackClient.

### DIFF
--- a/listener.py
+++ b/listener.py
@@ -42,7 +42,7 @@ def handle_messages(messages):
 def listen():
     """Start listening to slack channels the Testimonials Turtle bot is in."""
     # STOPSHIP: better error handling so an exception doesn't crash the module
-    client = slack.SlackClient(secrets.slack_testimonials_turtle_api_token)
+    client = slack.WebClient(secrets.slack_testimonials_turtle_api_token)
     if not client.rtm_connect():
         logging.critical("Failed to connect to Slack RTM API, bailing.")
         return

--- a/testimonials.py
+++ b/testimonials.py
@@ -99,7 +99,7 @@ def _send_as_bot(channel, msg, attachments):
 def _slack_api_call(
         method, token=secrets.slack_testimonials_turtle_api_token, **kwargs):
     """Make a slack API call, passing in all kwargs as request data."""
-    client = slack.SlackClient(token)
+    client = slack.WebClient(token)
     response_json = client.api_call(method, **kwargs)
 
     try:


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I didn't realize this before because the code I was testing uses
alertlib to send to slack, not the slack library.  But when I tried
testing ./listener.py I saw the error.

This isn't a total fix because I'm getting an "invalid_auth" error,
but I was getting that with the old version of this code too so we're
not any worse off, at lesat.

Issue: none

## Test plan:
env PYTHONPATH=lib ./listener.py