### PR TITLE
Add a sync-tag to webapp for the mutation we run.

### DIFF
--- a/webapp_api_client.py
+++ b/webapp_api_client.py
@@ -27,6 +27,7 @@ else:
 # To prevent it from being automatically deleted as a stale query, we
 # marked it as a 'mobile_native' query, even though it never appeared in a
 # mobile app.
+# sync-start:update-votes-mutation 1095670189 https://github.com/Khan/webapp/blob/master/deploy/manual_safelist.py
 UPDATE_VOTES_MUTATION = """
     mutation updateVotes(
       $storyKey:ID!,
@@ -44,6 +45,7 @@ UPDATE_VOTES_MUTATION = """
       }
     }
 """
+# sync-end:update-votes-mutation
 
 
 def _webapp_graphql_mutation(mutation, variables, operation_name):


### PR DESCRIPTION
## Summary:
Now that we can do sync-tags across repos, we can do this!

I don't know that this repo is still working, but we might as well
sync-tag it until we decide to delete it.

Issue: https://khanacademy.atlassian.net/browse/INFRA-10580

## Test plan:
checksync webapp_api_client.py