### PR TITLE
Protect all our API routes with a secret.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,19 @@ deps:
 serve: deps
 	env PYTHONPATH=lib python3 -m gunicorn -w 2 -b [::]:8080 --timeout 60 main:app --log-level debug
 
-test:
-	python3 -m unittest testimonials_test
+test: deps
+	env PYTHONPATH=lib python3 -m unittest testimonials_test
 
+# NOTE: we don't need to set PYTHONPATH here; it's done in appengine_config.py.
 deploy: secrets.py
 	gcloud app deploy app.yaml --project khan-testimonials-turtle --promote
 
-# to create secrets.py
+# To create secrets.py.
 secrets.py:
-	echo "slack_alertlib_webhook_url = '`gcloud --project khan-academy secrets versions access latest --secret Slack__webhook_url_for_alertlib`'" > "$@"
+	echo "slack_alertlib_api_token = '`gcloud --project khan-academy secrets versions access latest --secret districts_slack_token`'" > "$@"
 	echo "slack_testimonials_turtle_api_token = '`gcloud --project khan-academy secrets versions access latest --secret Slack__API_token_for_Testimonials_Turtle`'" >> "$@"
 	echo "slack_testimonials_search_api_token = '`gcloud --project khan-academy secrets versions access latest --secret Slack_API_token__for_search__for_Testimonials_Turtle`'" >> "$@"
 	echo "slack_testimonials_slash_command_token = '`gcloud --project khan-academy secrets versions access latest --secret Slack__API_token__for_slash_commands__for_Testimonials_Turtle`'" >> "$@"
+	echo "user_story_upvoting_secret = '`gcloud --project khan-academy secrets versions access latest --secret User_Story_Upvoting_Secret`'" >> "$@"
 
 .PHONY: deploy serve test deps

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ khan-testimonials-turtle GCP project.
 The slack client that listens for reactions to slack messages and updates vote
 totals (`listener.py`) runs on toby, using the configuration found
 [here](https://github.com/Khan/aws-config/blob/master/toby/etc/systemd/system/slack-testimonials-bot.service).
+
+---------------
+NOTE NOTE NOTE: This functionality is broken and has been deleted.
+NOTE NOTE NOTE: The below is purely information until listener.py is fixed
+NOTE NOTE NOTE: to use a more modern slack api.
+---------------
+
 To update that code, follow these steps:
 
 ```

--- a/webapp_api_client.py
+++ b/webapp_api_client.py
@@ -20,13 +20,6 @@ else:
     _WEBAPP_URL = "https://www.khanacademy.org"
 
 
-# NOTE(dhruv): This query was manually added to the graphql safelist in
-# production since we don't currently have an automated way of registering
-# these queries from this repository.
-
-# To prevent it from being automatically deleted as a stale query, we
-# marked it as a 'mobile_native' query, even though it never appeared in a
-# mobile app.
 # sync-start:update-votes-mutation 1095670189 https://github.com/Khan/webapp/blob/master/deploy/manual_safelist.py
 UPDATE_VOTES_MUTATION = """
     mutation updateVotes(


### PR DESCRIPTION
## Summary:
We had an issue where outside attackers were posting spam #1s-and-0s,
because they discovered that our testimonials-bot /promote_story
endpoint is unprotected.  Let's fix that!

We have already changed webapp to pass in a secret to every API call
they make to us.  This PR finishes the job by checking for that secret
before doing any work.

I fixed up the Makefile in the process of testing.  I also fixed up
the README to match current reality.

Issue: https://khanacademy.slack.com/archives/C029GG415/p1745104241118619

## Test plan:
make check

I also ran `make serve` and then ran:
```
curl -d 'key=1&body=2&date=4&share_allowed=5' localhost:8080/api/promote_testimonial
```
and got a 401 error, as desired.  I then did:
```
curl -d 'key=1&body=2&date=4&share_allowed=5&auth_secret=<slack_testimonials_turtle_api_token value from secrets.py>' localhost:8080/api/promote_testimonial
```
and got a 200 response.